### PR TITLE
Mobile tab title

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ guide the learner’s interaction with the component.
 
 **_tabLayout** (string): Defines the layout of the tabs. Acceptable values are `left` and `top`. By default, component displays `left` layout for medium screen size and below.
 
-**_items** (array): Multiple items may be created. Each *_item* represents one element of the tabs component and contains values for **tabTitle**, **title**, **body**, and **_graphic**. 
+**_items** (array): Multiple items may be created. Each *_item* represents one element of the tabs component and contains values for **tabTitle**, **mobileTabTitle**, **title**, **body**, and **_graphic**. 
 
 >**tabTitle** (string): This text is displayed in the actual tab heading. Recommend keeping this title short.
+
+>**mobileTabTitle** (string): This optional text is displayed in the actual tab heading on mobile devices, replacing **tabTitle**.
 
 >**title** (string): This text is displayed as the content panel's header. It is displayed when the tab has been selected.
 

--- a/example.json
+++ b/example.json
@@ -14,6 +14,7 @@
     "_items": [
         {
             "tabTitle": "Tab Title 1",
+            "mobileTabTitle": "1.",
             "title": "Tab item 1 title",
             "body": "This is display text 1. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.",
             "_graphic": {
@@ -23,6 +24,7 @@
         },
         {
             "tabTitle": "Tab Title 2",
+            "mobileTabTitle": "2.",
             "title": "Tab item 2 title",
             "body": "This is display text 2. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.",
             "_graphic": {
@@ -32,6 +34,7 @@
         },
         {
             "tabTitle": "Tab Title 3",
+            "mobileTabTitle": "3.",
             "title": "Tab item 3 title",
             "body": "This is display text 3. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.",
             "_graphic": {
@@ -41,6 +44,7 @@
         },
         {
             "tabTitle": "Tab Title 4",
+            "mobileTabTitle": "4.",
             "title": "Tab item 4 title",
             "body": "This is display text 4. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.",
             "_graphic": {

--- a/js/adapt-tabs.js
+++ b/js/adapt-tabs.js
@@ -54,17 +54,10 @@ define(function(require) {
 
 		setTabText: function() {
 			var items = this.model.get('_items');
-			if (Adapt.device.screenSize == 'small') {
-				_.each(items, function (item, index) {
-					if (item.mobileTabTitle) {
-						this.$('.tabs-navigation-item-inner').eq(index).html(item.mobileTabTitle);
-					}
-				});
-			} else {
-				_.each(items, function (item, index) {
-						this.$('.tabs-navigation-item-inner').eq(index).html(item.tabTitle);
-				});
-			}
+			_.each(items, function (item, index) {
+				var tabTitle = (Adapt.device.screenSize === 'small' && item.mobileTabTitle) ? item.mobileTabTitle : item.tabTitle;
+				this.$('.tabs-navigation-item-inner').eq(index).html(tabTitle);
+			}, this);
 		},
 
 		onTabItemClicked: function(event) {

--- a/js/adapt-tabs.js
+++ b/js/adapt-tabs.js
@@ -34,6 +34,7 @@ define(function(require) {
 				this.$el.addClass("tab-layout-left");
 				this.setTabLayoutLeft();
 			}        	
+			this.setTabText();
 		},
 
 		setTabLayoutTop: function() {
@@ -49,6 +50,21 @@ define(function(require) {
 			this.$('.tabs-navigation-item').css({
 				width: 100 + '%'
 			});
+		},
+
+		setTabText: function() {
+			var items = this.model.get('_items');
+			if (Adapt.device.screenSize == 'small') {
+				_.each(items, function (item, index) {
+					if (item.mobileTabTitle) {
+						this.$('.tabs-navigation-item-inner').eq(index).html(item.mobileTabTitle);
+					}
+				});
+			} else {
+				_.each(items, function (item, index) {
+						this.$('.tabs-navigation-item-inner').eq(index).html(item.tabTitle);
+				});
+			}
 		},
 
 		onTabItemClicked: function(event) {

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -228,5 +228,10 @@
 		.tabs-content-items-inner {
 			padding: @item-padding/2;
 		}
+
+		.tab-content-item-graphic {
+		  	text-align: center;
+		  	margin: auto;
+		}
 	}
 }

--- a/properties.schema
+++ b/properties.schema
@@ -55,6 +55,15 @@
             "validators": ["required"],
             "help": "This is the tab item title"
           },
+          "mobileTabTitle": {
+            "type": "string",
+            "required": false,
+            "inputType": "Text",
+            "title": "Mobile Tab Item Title",
+            "default": "",
+            "validators": [],
+            "help": "This is the tab item title displayed on small devices"
+          },
           "title": {
             "type": "string",
             "required": true,


### PR DESCRIPTION
Truncating tab titles on mobile devices isn't always effective. See images.

2 changes proposed:
- Added a mobileTabTitle to allow the author to explicitly assign the desired text. 
- Also centered the item graphic on mobile.
  (In the images you'll notice we retained the top tab layout in mobile. This is not germane to the PR, but I did want anyone to get distracted by thinking it was.) 

![screen shot 2015-10-24 at 4 48 24 pm](https://cloud.githubusercontent.com/assets/9489014/10713523/bc455e96-7a89-11e5-9ad2-3ee199b6d11e.png)  

![screen shot 2](https://cloud.githubusercontent.com/assets/9489014/10713618/b690bd88-7a8e-11e5-837c-377f76942423.jpg)
![screen shot 3](https://cloud.githubusercontent.com/assets/9489014/10713620/bbcba704-7a8e-11e5-9944-664019b6e6e0.jpg)
