### PR TITLE
Adds alt tag quotes for proper rendering

### DIFF
--- a/templates/tabs.hbs
+++ b/templates/tabs.hbs
@@ -15,7 +15,7 @@
 						</div>
 					</div>
 					{{/if}}
-					
+
 					{{#if body}}
 					<div class="tab-content-item-body">
 						<div class="tab-content-item-body-inner">
@@ -26,7 +26,7 @@
 
 					{{#if _graphic.src}}
 					<div class="tab-content-item-graphic">
-						<img class="tab-content-item-graphic-inner" src="{{{_graphic.src}}}" alt={{{_graphic.alt}}} tabindex="0"/>
+						<img class="tab-content-item-graphic-inner" src="{{{_graphic.src}}}" alt="{{{_graphic.alt}}}" tabindex="0"/>
 					</div>
 					{{/if}}
 


### PR DESCRIPTION
This fixes an issue where the `img` tag inside a tab was rendering with some of the alt text outside of the attribute quotes, like so: 

```
<img class="tab-content-item-graphic-inner aria-hidden" src="course/en/images/hearing-sm.gif" alt="Girl" using hearing aid tabindex="-1" aria-hidden="true">
```