### PR TITLE
issue/32 Fixed tabbing

### DIFF
--- a/js/TabsView.js
+++ b/js/TabsView.js
@@ -57,20 +57,13 @@ class TabsView extends ComponentView {
     if (e && e.preventDefault) e.preventDefault();
     const index = $(e.currentTarget).data('index');
     this.model.setActiveItem(index);
-    const $tabs = $(e.currentTarget).parents('[role=tablist]').find('[role=tab]');
     const $tabPanel = $(e.currentTarget).parents('.tabs__widget').find('[role=tabpanel]');
-    const filteredTabs = $tabs.filter(tab => tab !== index);
-    a11y.toggleAccessible($tabs, true);
-    a11y.toggleAccessible(filteredTabs, false);
     a11y.focus($tabPanel[index]);
   }
 
   onTabItemKeyUp(event) {
     // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role
     const $tabs = $(event.currentTarget).parents('[role=tablist]').find('[role=tab]');
-    const $tabPanel = $(event.currentTarget).parents('.tabs__widget').find('[role=tabpanel]');
-    a11y.toggleAccessible($tabs, true);
-    a11y.toggleAccessible($tabPanel, false);
     if (!$tabs.length) return;
     let currentIndex = $tabs.toArray().findIndex(tab => tab === event.currentTarget);
     switch (event.which) {
@@ -84,10 +77,6 @@ class TabsView extends ComponentView {
     }
     this.model.setActiveItem(currentIndex);
     a11y.focus($tabs[currentIndex]);
-    const filteredTabs = $tabs.filter(tab => tab !== currentIndex);
-    const filteredTabPanel = $tabPanel.filter(tabPanel => tabPanel === currentIndex);
-    a11y.toggleAccessible(filteredTabs, false);
-    filteredTabPanel.attr({ tabindex: '0' });
   }
 
 }

--- a/js/TabsView.js
+++ b/js/TabsView.js
@@ -55,12 +55,21 @@ class TabsView extends ComponentView {
 
   onTabItemClicked(e) {
     if (e && e.preventDefault) e.preventDefault();
-    this.model.setActiveItem($(e.currentTarget).data('index'));
+    const index = $(e.currentTarget).data('index');
+    this.model.setActiveItem(index);
+    const $tabs = $(e.currentTarget).parents('[role=tablist]').find('[role=tab]');
+    const $tabPanel = $(e.currentTarget).parents('.tabs__widget').find('[role=tabpanel]');
+    const filteredTabs = $tabs.filter(tab => tab !== index);
+    a11y.toggleAccessibleEnabled(filteredTabs, false);
+    a11y.focus($tabPanel[index]);
   }
 
   onTabItemKeyUp(event) {
     // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role
     const $tabs = $(event.currentTarget).parents('[role=tablist]').find('[role=tab]');
+    const $tabPanel = $(event.currentTarget).parents('.tabs__widget').find('[role=tabpanel]');
+    a11y.toggleAccessibleEnabled($tabs, true);
+    a11y.toggleAccessibleEnabled($tabPanel, false);
     if (!$tabs.length) return;
     let currentIndex = $tabs.toArray().findIndex(tab => tab === event.currentTarget);
     switch (event.which) {
@@ -72,7 +81,12 @@ class TabsView extends ComponentView {
         if (currentIndex === $tabs.length - 1) currentIndex = -1;
         currentIndex++;
     }
+    this.model.setActiveItem(currentIndex);
     a11y.focus($tabs[currentIndex]);
+    const filteredTabs = $tabs.filter(tab => tab !== currentIndex);
+    const filteredTabPanel = $tabPanel.filter(tabPanel => tabPanel === currentIndex);
+    a11y.toggleAccessibleEnabled(filteredTabs, false);
+    filteredTabPanel.attr({ tabindex: '0' });
   }
 
 }

--- a/js/TabsView.js
+++ b/js/TabsView.js
@@ -60,7 +60,8 @@ class TabsView extends ComponentView {
     const $tabs = $(e.currentTarget).parents('[role=tablist]').find('[role=tab]');
     const $tabPanel = $(e.currentTarget).parents('.tabs__widget').find('[role=tabpanel]');
     const filteredTabs = $tabs.filter(tab => tab !== index);
-    a11y.toggleAccessibleEnabled(filteredTabs, false);
+    a11y.toggleAccessible($tabs, true);
+    a11y.toggleAccessible(filteredTabs, false);
     a11y.focus($tabPanel[index]);
   }
 
@@ -68,8 +69,8 @@ class TabsView extends ComponentView {
     // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role
     const $tabs = $(event.currentTarget).parents('[role=tablist]').find('[role=tab]');
     const $tabPanel = $(event.currentTarget).parents('.tabs__widget').find('[role=tabpanel]');
-    a11y.toggleAccessibleEnabled($tabs, true);
-    a11y.toggleAccessibleEnabled($tabPanel, false);
+    a11y.toggleAccessible($tabs, true);
+    a11y.toggleAccessible($tabPanel, false);
     if (!$tabs.length) return;
     let currentIndex = $tabs.toArray().findIndex(tab => tab === event.currentTarget);
     switch (event.which) {
@@ -85,7 +86,7 @@ class TabsView extends ComponentView {
     a11y.focus($tabs[currentIndex]);
     const filteredTabs = $tabs.filter(tab => tab !== currentIndex);
     const filteredTabPanel = $tabPanel.filter(tabPanel => tabPanel === currentIndex);
-    a11y.toggleAccessibleEnabled(filteredTabs, false);
+    a11y.toggleAccessible(filteredTabs, false);
     filteredTabPanel.attr({ tabindex: '0' });
   }
 

--- a/templates/tabs.jsx
+++ b/templates/tabs.jsx
@@ -43,6 +43,7 @@ export default function Tabs(props) {
                   _isVisited && 'is-visited',
                   _isActive && 'is-selected'
                 ])}
+                tabIndex={_isActive ? 0 : -1}
                 onClick={onTabItemClicked}
                 onKeyUp={onTabItemKeyUp}
                 style={{ width: itemWidth }}

--- a/templates/tabs.jsx
+++ b/templates/tabs.jsx
@@ -37,7 +37,6 @@ export default function Tabs(props) {
                 aria-selected={_isActive}
                 aria-controls={`${_id}-${index}-tabpanel`}
                 aria-label={`${tabTitle}.${_isVisited ? ` ${_globals._accessibility._ariaLabels.visited}` : ''}`}
-                tabIndex={_isActive ? 0 : -1}
                 className={classes([
                   'tabs__nav-item-btn',
                   'js-tabs-nav-item-btn-click',

--- a/templates/tabs.jsx
+++ b/templates/tabs.jsx
@@ -38,7 +38,7 @@ export default function Tabs(props) {
                 aria-controls={`${_id}-${index}-tabpanel`}
                 aria-hidden={!_isActive || null}
                 aria-label={`${tabTitle}.${_isVisited ? ` ${_globals._accessibility._ariaLabels.visited}` : ''}`}
-                tabIndex={`${_isActive ? 0 : -1}`}
+                tabIndex={_isActive ? 0 : -1}
                 className={classes([
                   'tabs__nav-item-btn',
                   'js-tabs-nav-item-btn-click',
@@ -75,7 +75,7 @@ export default function Tabs(props) {
                 role="tabpanel"
                 aria-hidden={!_isActive || null}
                 aria-labelledby={`${_id}-${index}-tabtitle`}
-                tabIndex={`${_isActive ? 0 : -1}`}
+                tabIndex={_isActive ? 0 : -1}
                 data-index={_index}
                 className={classes([
                   'tabs__content-item',

--- a/templates/tabs.jsx
+++ b/templates/tabs.jsx
@@ -36,7 +36,9 @@ export default function Tabs(props) {
                 role="tab"
                 aria-selected={_isActive}
                 aria-controls={`${_id}-${index}-tabpanel`}
+                aria-hidden={!_isActive || null}
                 aria-label={`${tabTitle}.${_isVisited ? ` ${_globals._accessibility._ariaLabels.visited}` : ''}`}
+                tabIndex={`${_isActive ? 0 : -1}`}
                 className={classes([
                   'tabs__nav-item-btn',
                   'js-tabs-nav-item-btn-click',
@@ -73,6 +75,7 @@ export default function Tabs(props) {
                 role="tabpanel"
                 aria-hidden={!_isActive || null}
                 aria-labelledby={`${_id}-${index}-tabtitle`}
+                tabIndex={`${_isActive ? 0 : -1}`}
                 data-index={_index}
                 className={classes([
                   'tabs__content-item',

--- a/templates/tabs.jsx
+++ b/templates/tabs.jsx
@@ -36,7 +36,6 @@ export default function Tabs(props) {
                 role="tab"
                 aria-selected={_isActive}
                 aria-controls={`${_id}-${index}-tabpanel`}
-                aria-hidden={!_isActive || null}
                 aria-label={`${tabTitle}.${_isVisited ? ` ${_globals._accessibility._ariaLabels.visited}` : ''}`}
                 tabIndex={_isActive ? 0 : -1}
                 className={classes([


### PR DESCRIPTION
Fixes (https://github.com/cgkineo/adapt-tabs/issues/32)

When navigating tabs with the arrow keys the activeItem will update, the user can then either tab to the content panel, or press enter, they can then use shift+tab to move back to the tab. 