### PR TITLE
Fix: Added generic 'component' classes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-tabs",
   "framework": ">=5.14",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "homepage": "https://github.com/cgkineo/adapt-tabs",
   "issues": "https://github.com/cgkineo/adapt-tabs/issues/",
   "displayName": "Tabs",

--- a/js/TabsView.js
+++ b/js/TabsView.js
@@ -7,6 +7,7 @@ class TabsView extends ComponentView {
 
   className() {
     return [
+      super.className(),
       `is-${this.layout}-layout`
     ].join(' ');
   }


### PR DESCRIPTION
fixe #31 

### Fix
* Generic component classes are brought through from the `ComponentView`