### PR TITLE
Fix: Removed deprecated behaviour

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-tabs",
   "framework": ">=5.14",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "homepage": "https://github.com/cgkineo/adapt-tabs",
   "issues": "https://github.com/cgkineo/adapt-tabs/issues/",
   "displayName": "Tabs",

--- a/js/TabsView.js
+++ b/js/TabsView.js
@@ -25,7 +25,7 @@ class TabsView extends ComponentView {
     this.onTabItemClicked = this.onTabItemClicked.bind(this);
     this.onTabItemKeyUp = this.onTabItemKeyUp.bind(this);
     this.listenTo(Adapt, 'device:resize', this.setItemWidth);
-    this.listenTo(this.model.get('_children'), 'change:_isActive', this.onItemsActiveChange);
+    this.listenTo(this.model.getChildren(), 'change:_isActive', this.onItemsActiveChange);
   }
 
   reset() {

--- a/js/adapt-tabs.js
+++ b/js/adapt-tabs.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import TabsView from './TabsView';
 import ItemsComponentModel from 'core/js/models/itemsComponentModel';
 
-export default Adapt.register('tabs', {
+export default components.register('tabs', {
   model: ItemsComponentModel.extend({}),
   view: TabsView
 });


### PR DESCRIPTION
### Fix
* Changed `get('_children')` to `getChildren()`
* Changed `Adapt.register` to `components.register`